### PR TITLE
xml output

### DIFF
--- a/src/main/java/controller/Search.java
+++ b/src/main/java/controller/Search.java
@@ -114,6 +114,7 @@ public class Search extends HttpServlet {
     	String encoding = request.getCharacterEncoding();
     	if(encoding==null || encoding.trim().isEmpty()) encoding = "UTF-8";
     	response.setContentType("text/xml");
+    	response.setCharacterEncoding(encoding);
     	final OutputStream out = response.getOutputStream();
     	try {
     		final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();

--- a/src/main/java/controller/Search.java
+++ b/src/main/java/controller/Search.java
@@ -1,13 +1,21 @@
 package controller;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
 import model.Download;
 import model.Output;
 import model.Upload;
+import object.VariantGeneScore;
 import util.DBManager;
 
 /**
@@ -51,7 +59,19 @@ public class Search extends HttpServlet {
                 setRequest(request, query);
             }
 
-            request.getRequestDispatcher("index.jsp").forward(request, response);
+            final String content_type = request.getParameter("content-type");
+            if("text/xml".equals(content_type) && 
+            		Upload.uploadErrMsg!=null &&
+            		Output.isRegionValid &&
+            		!Download.isDownloadOnly
+            		)
+            	{
+            	writeVariantsAsXml(request, response, Output.variantGeneScoreList);
+            	}
+            else
+            	{
+            	request.getRequestDispatcher("index.jsp").forward(request, response);
+            	}
         } catch (Exception ex) {
 //            request.setAttribute("errorMsg4Debug", ex.toString());
             request.getRequestDispatcher("error.jsp").forward(request, response);
@@ -84,4 +104,39 @@ public class Search extends HttpServlet {
     public String getServletInfo() {
         return "trap search query";
     }
+    
+    /** output a variant list as XML */
+    private void writeVariantsAsXml(
+    		final HttpServletRequest request,
+    		final HttpServletResponse response,
+    		final List<VariantGeneScore> variants
+    		) throws ServletException,IOException {
+    	String encoding = request.getCharacterEncoding();
+    	if(encoding==null || encoding.trim().isEmpty()) encoding = "UTF-8";
+    	response.setContentType("text/xml");
+    	final OutputStream out = response.getOutputStream();
+    	try {
+    		final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
+    		final XMLStreamWriter w= xmlOutputFactory.createXMLStreamWriter(out,encoding);
+    		w.writeStartDocument(encoding, "1.0");
+    		w.writeStartElement("trap");
+    		w.writeComment("TraP is protected by copyright. 2017 The Trustees of Columbia University in the City of New York.");
+    		if(variants!=null)
+	    		{
+	    		for(final VariantGeneScore variant: variants)
+	    			{
+	    			variant.writeAsXml(w);
+	    			}
+	    		}
+    		w.writeEndElement();//close element 'trap'
+    		w.writeEndDocument();
+    		w.flush();
+    		w.close();
+    		}
+    	catch(final XMLStreamException err)
+    		{
+    		throw new IOException(err);
+    		}
+    	try {out.flush();} catch(IOException err) {} 
+    	}
 }

--- a/src/main/java/object/VariantGeneScore.java
+++ b/src/main/java/object/VariantGeneScore.java
@@ -1,5 +1,8 @@
 package object;
 
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
 /**
  *
  * @author Nick
@@ -70,6 +73,31 @@ public class VariantGeneScore {
         return score;
     }
 
+    /** helper function to write <tag>value</tag> */
+    private static void writeValueAsXml(final XMLStreamWriter w,final String tag,final Object value) throws XMLStreamException {
+    	if(value==null) return;
+    	final String s = String.valueOf(value);
+    	if(s.trim().isEmpty()) return;
+    	w.writeStartElement(tag);
+    	w.writeCharacters(s);
+    	w.writeEndElement();
+    	}
+    
+    /** save this variant as XML */
+    public void writeAsXml(final XMLStreamWriter w) throws XMLStreamException {
+    	w.writeStartElement("VariantGeneScore");
+    	w.writeAttribute("id", this.variantId);
+    	writeValueAsXml(w,"Chr", this.chr);
+    	writeValueAsXml(w,"Pos", this.pos);
+    	writeValueAsXml(w,"Ref", this.ref);
+    	writeValueAsXml(w,"Alt", this.alt);
+    	writeValueAsXml(w,"ENSG", this.ensgGene);
+    	writeValueAsXml(w,"HGNC", this.hgncGene);
+    	writeValueAsXml(w,"score", this.score);
+    	w.writeEndElement();//close 'variant'
+    }
+    
+    
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Hi,
This pull request should enable a XML output when a user specify` content-type=text/xml` in the query. This will avoid some screen-scrapers to try to decode your html page...

I've added a method in servlet to dump the variant list as XML and a generic method in VariantGeneScore to dump a variant;

**Of course, I cannot test this on my side but I hope it works.**

> Aside of this: i'm deeply sorry but your whole servlet doesn't handle concurrent requests because there are too many **static** fields everywhere:. The way you're handling your SQL queries is dangerous too: there is only one connection for the whole server while you should use a **ConnectionPool** . If two requests are sent at the same time, the `statement` variable cannot handle this.